### PR TITLE
chore: add npm start script for deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 	"main": "index.js",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",
+		"start": "node server.js",
 		"dev": "nodemon server.js",
 		"check": "prettier --check .",
 		"format": "prettier --write ."


### PR DESCRIPTION
Render deployment requires the script 'npm run start' for deployment so I added that in.