### PR TITLE
fix: case sensitivity issue for /myBooks route on Linux server

### DIFF
--- a/public/templates/navbar.ejs
+++ b/public/templates/navbar.ejs
@@ -6,8 +6,8 @@
 		</div>
 		<div class="remaining-users hidden"></div>
 	</li>
-	<% if (url != "/mybooks/") { %>
-		<li><a href="/mybooks/">My Books</a></li>
+	<% if (url != "/myBooks/") { %>
+		<li><a href="/myBooks/">My Books</a></li>
 	<% } %>
 	
 	<% if (url != "/library-interior/") { %>


### PR DESCRIPTION
changed '/mybooks' to be '/myBooks'. I'm working on deploying our app and am using 'Render' to do so. I was running into an issue where when you clicked the My Books link in the nav bar it would server error. This turned out to be because on linux, which the deployed version runs on, is case-sensitive for the url's and windows isn't. 